### PR TITLE
Optional flag to disable logs

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -543,7 +543,7 @@ class LemmyBot {
       modBanFromSite: modBanFromSiteOptions
     } = this.#handlers;
 
-    await setupDB(this.#enableLogs, this.#dbFile);
+    await setupDB(this.#log, this.#dbFile);
 
     if (this.#credentials) {
       await this.#login();
@@ -681,11 +681,7 @@ class LemmyBot {
                     read: true
                   });
 
-                  if(this.#enableLogs){
-                    console.log(
-                      `Marked private message ID ${messageView.private_message.id} from ${messageView.creator.id} as read`
-                    );
-                  }
+                  this.#log(`Marked private message ID ${messageView.private_message.id} from ${messageView.creator.id} as read`);
 
                   return promise;
                 }
@@ -1156,39 +1152,29 @@ class LemmyBot {
   }
 
   start() {
-    if(this.#enableLogs){
-      console.log('Starting bot');
-    }
+    this.#log('Starting bot');
     this.#isRunning = true;
     this.#runBot();
   }
 
   stop() {
-    if(this.#enableLogs){
-      console.log('stopping bot');
-    }
+    this.#log('Stopping bot');
     this.#isRunning = false;
   }
 
   async #login() {
     if (this.#credentials) {
-      if(this.#enableLogs){
-        console.log('logging in');
-      }
+      this.#log('Logging in');
       const loginRes = await this.#httpClient.login({
         password: this.#credentials.password,
         username_or_email: this.#credentials.username
       });
       this.#auth = loginRes.jwt;
       if (this.#auth) {
-        if(this.#enableLogs){
-          console.log('logged in');
-        }
+        this.#log('Logged in');
 
         if (this.#markAsBot) {
-          if(this.#enableLogs){
-            console.log('Marking account as bot account');
-          }
+          this.#log('Marking account as bot account');
 
           await this.#httpClient
             .saveUserSettings({
@@ -1392,10 +1378,14 @@ class LemmyBot {
     action: () => Promise<T>;
   }) {
     if (this.#auth) {
-      if(this.#enableLogs){
-        console.log(logMessage);
-      }
+      this.#log(logMessage);
       await action();
+    }
+  }
+
+  #log = (output: string) => {
+    if (this.#enableLogs) {
+      console.log(output);
     }
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -154,9 +154,11 @@ const createTable = (db: Database, table: string) => {
   db.run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_${table}_id ON ${table} (id);`);
 };
 
-export const setupDB = async (dbPath?: string) => {
+export const setupDB = async (enableLogs: boolean, dbPath?: string) => {
   if (dbPath && !existsSync(dbPath)) {
-    console.log('Creating database file');
+    if (enableLogs) {
+      console.log('Creating database file');
+    }
 
     try {
       await mkdir(path.dirname(dbPath), { recursive: true });
@@ -170,7 +172,9 @@ export const setupDB = async (dbPath?: string) => {
 
   await useDatabase(async (db) => {
     db.serialize(() => {
-      console.log('Initializing DB');
+      if (enableLogs) {
+        console.log('Initializing DB');
+      }
       for (const table of tableTypes) {
         createTable(db, table);
       }

--- a/src/db.ts
+++ b/src/db.ts
@@ -154,11 +154,9 @@ const createTable = (db: Database, table: string) => {
   db.run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_${table}_id ON ${table} (id);`);
 };
 
-export const setupDB = async (enableLogs: boolean, dbPath?: string) => {
+export const setupDB = async (log: (output: string) => void, dbPath?: string) => {
   if (dbPath && !existsSync(dbPath)) {
-    if (enableLogs) {
-      console.log('Creating database file');
-    }
+    log('Creating database file');
 
     try {
       await mkdir(path.dirname(dbPath), { recursive: true });
@@ -172,9 +170,7 @@ export const setupDB = async (enableLogs: boolean, dbPath?: string) => {
 
   await useDatabase(async (db) => {
     db.serialize(() => {
-      if (enableLogs) {
-        console.log('Initializing DB');
-      }
+      log('Initializing DB');
       for (const table of tableTypes) {
         createTable(db, table);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,13 @@ export type BotOptions = {
    * @default true
    */
   markAsBot?: boolean;
+  /**
+   * If true, the bot will output verbose logs for any operation it conducts.
+   * If set to false, no internal logs will be produced.
+   *
+   * @default true
+   */
+  enableLogs?: boolean;
 };
 
 export type ParentType = 'post' | 'comment';


### PR DESCRIPTION
Solves #65 .

I have added an optional `enableLogs` boolean flag in the constructor to disable all ordinary internal loggings.

This flag does **not** disable error loggings.

I was unable to disable database logging. I thought this was caused by the verbose() function being called in `db.ts` but I kept getting logs from there even after having commented it out and replaced with different import statements.

```ts
import { verbose, Database } from 'sqlite3';

const sqlite = verbose();
```
Regardless, the only output I was able to notice because of this was a single line saying:

> user_already_exists

on startup. While annoying, it's significantly better than how it was before.